### PR TITLE
Cancel stale operations to prevent UI races.

### DIFF
--- a/factorer.go
+++ b/factorer.go
@@ -58,13 +58,18 @@ func (f *factorer) Factor(ctx context.Context, x int) ([]int, error) {
 	// Compute the prime factorization.
 	var factors []int
 	original := x
-	for x >= 2 {
-		for factor := 2; factor <= x; factor++ {
-			if x%factor == 0 {
-				factors = append(factors, factor)
-				x = x / factor
-				break
-			}
+	for factor := 2; factor <= x; {
+		if x%factor == 0 {
+			factors = append(factors, factor)
+			x /= factor
+		} else {
+			factor++
+		}
+
+		// Periodically check whether ctx has been cancelled.
+		if factor%1000 == 0 && ctx.Err() != nil {
+			f.Logger().Debug("Factor cancelled", "x", x)
+			return nil, ctx.Err()
 		}
 	}
 	sort.Ints(factors)

--- a/index.html
+++ b/index.html
@@ -96,13 +96,13 @@
     </div>
 
     <script>
-      async function factor(x) {
-        const response = await fetch(`/factor?x=${x}`);
+      async function factor(x, aborter) {
+        const response = await fetch(`/factor?x=${x}`, {signal: aborter});
         return await response.text();
       }
 
-      async function chatgpt_factor(x) {
-        const response = await fetch(`/chatgpt_factor?x=${x}`);
+      async function chatgpt_factor(x, aborter) {
+        const response = await fetch(`/chatgpt_factor?x=${x}`, {signal: aborter});
         return await response.text();
       }
 
@@ -113,18 +113,29 @@
         const chatgpt_factors = document.getElementById('chatgpt_factors');
         const button = document.getElementById('factor_button');
 
+        let controller;
         const send_request = () => {
           chatgpt_x.innerHTML = x.value;
           factors.innerHTML = `Loading factors of ${x.value}...`;
           chatgpt_factors.innerHTML = `Loading factors of ${x.value}...`;
-          factor(x.value).then((v) => {
+
+          // Cancel any pending operations.
+          if (controller != undefined) {
+            controller.abort();
+          }
+          controller = new AbortController();
+
+          // Call the /factor endpoint.
+          factor(x.value, controller.signal).then((v) => {
             try {
               factors.innerHTML = JSON.parse(v).join(", ");
             } catch {
               factors.innerHTML = v
             }
           });
-          chatgpt_factor(x.value).then((v) => {
+
+          // Call the /chatgpt_factor endpoint.
+          chatgpt_factor(x.value, controller.signal).then((v) => {
             chatgpt_factors.innerHTML = v;
           });
         }


### PR DESCRIPTION
When a user clicks the "Factor" button, it sends a request to the backend to factor the provided number. When the backend returns, the frontend updates the UI with the factors.

Before this PR, this logic was susceptible to races. In particular, if a user requests the factorization or a large prime, the request lingers for a while. If they give up and request the factorization of a much smaller number, the factorization finishes very quickly. Then, the lingering factorization finishes and overwrites the current factorization. This is bad.

This PR fixes the bug. Now, whenever a user clicks the "Factor" button, the previous request is cancelled, if it didn't finish already. Relatedly, I also updated the Factorer component to respect cancelled contexts.

See https://javascript.info/fetch-abort for background on cancelling Javascript promises.