### PR TITLE
Added unit tests for instructions.

### DIFF
--- a/01/instructions_test.go
+++ b/01/instructions_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	if err := exec.Command("go", "mod", "tidy").Run(); err != nil {
+		t.Fatalf("go mod tidy: %v", err)
+	}
+
+	if err := exec.Command("weaver", "generate", ".").Run(); err != nil {
+		t.Fatalf("weaver generate .: %v", err)
+	}
+
+	out, err := exec.Command("go", "run", ".").Output()
+	if err != nil {
+		t.Fatalf("go run .: %v", err)
+	}
+	if string(out) != "Hello, World!\n" {
+		t.Fatalf("go run .: got %q, want %q", string(out), "Hello, World!\n")
+	}
+}

--- a/02/instructions_test.go
+++ b/02/instructions_test.go
@@ -1,0 +1,37 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	if err := exec.Command("weaver", "generate", ".").Run(); err != nil {
+		t.Fatalf("weaver generate .: %v", err)
+	}
+
+	out, err := exec.Command("go", "run", ".").Output()
+	if err != nil {
+		t.Fatalf("go run .: %v", err)
+	}
+	const want = "[🐖 🐗 🐷 🐽]\n"
+	if string(out) != want {
+		t.Fatalf("go run .: got %q, want %q", string(out), want)
+	}
+}

--- a/04/instructions_test.go
+++ b/04/instructions_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	// Start the server.
+	server := exec.Command("go", "run", ".")
+	server.Env = append(server.Environ(), "SERVICEWEAVER_CONFIG=config.toml")
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := server.Process.Kill(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give the server time to start.
+	time.Sleep(time.Second)
+
+	// Curl the server.
+	for _, test := range []struct{ url, want string }{
+		{"localhost:9000/search?q=pig", `["🐖","🐗","🐷","🐽"]` + "\n"},
+		{"localhost:9000/search?q=cow", `["🐄","🐮"]` + "\n"},
+		{"localhost:9000/search?q=baby%20bird", `["🐣","🐤","🐥"]` + "\n"},
+	} {
+		out, err := exec.Command("curl", test.url).Output()
+		if err != nil {
+			t.Fatalf("curl %s: %v", test.url, err)
+		}
+		if string(out) != test.want {
+			t.Fatalf("curl %s: got %q, want %q", test.url, string(out), test.want)
+		}
+	}
+
+	// Run "weaver single status".
+	if err := exec.Command("weaver", "single", "status").Run(); err != nil {
+		t.Fatalf("weaver single status .: %v", err)
+	}
+}

--- a/05/README.md
+++ b/05/README.md
@@ -24,7 +24,7 @@ $ curl localhost:9000/search?q=sushi
 $ curl localhost:9000/search?q=curry
 ["🍛"]
 $ curl localhost:9000/search?q=shrimp
-["🍤", "🦐"]
+["🍤","🦐"]
 $ curl localhost:9000/search?q=lobster
 ["🦞"]
 ```

--- a/05/instructions_test.go
+++ b/05/instructions_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	// Start the server.
+	server := exec.Command("go", "run", ".")
+	server.Env = append(server.Environ(), "SERVICEWEAVER_CONFIG=config.toml")
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := server.Process.Kill(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give the server time to start.
+	time.Sleep(time.Second)
+
+	// Curl the server.
+	for _, test := range []struct{ url, want string }{
+		{"localhost:9000/search?q=sushi", `["🍣"]` + "\n"},
+		{"localhost:9000/search?q=curry", `["🍛"]` + "\n"},
+		{"localhost:9000/search?q=shrimp", `["🍤","🦐"]` + "\n"},
+		{"localhost:9000/search?q=lobster", `["🦞"]` + "\n"},
+	} {
+		out, err := exec.Command("curl", test.url).Output()
+		if err != nil {
+			t.Fatalf("curl %s: %v", test.url, err)
+		}
+		if string(out) != test.want {
+			t.Fatalf("curl %s: got %q, want %q", test.url, string(out), test.want)
+		}
+	}
+}

--- a/06/instructions_test.go
+++ b/06/instructions_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	// Build the binary.
+	if err := exec.Command("go", "build", ".").Run(); err != nil {
+		t.Fatalf("go build .: %v", err)
+	}
+
+	// Start the server.
+	server := exec.Command("weaver", "multi", "deploy", "config.toml")
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := server.Process.Kill(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give the server time to start.
+	time.Sleep(time.Second)
+
+	// Inspect the status.
+	if err := exec.Command("weaver", "multi", "status").Run(); err != nil {
+		t.Fatalf("weaver multi status: %v", err)
+	}
+
+	// Curl the server.
+	for _, test := range []struct{ url, want string }{
+		{"localhost:9000/search?q=sushi", `["🍣"]` + "\n"},
+		{"localhost:9000/search?q=curry", `["🍛"]` + "\n"},
+		{"localhost:9000/search?q=shrimp", `["🍤","🦐"]` + "\n"},
+		{"localhost:9000/search?q=lobster", `["🦞"]` + "\n"},
+	} {
+		out, err := exec.Command("curl", test.url).Output()
+		if err != nil {
+			t.Fatalf("curl %s: %v", test.url, err)
+		}
+		if string(out) != test.want {
+			t.Fatalf("curl %s: got %q, want %q", test.url, string(out), test.want)
+		}
+	}
+}

--- a/07/README.md
+++ b/07/README.md
@@ -54,10 +54,10 @@ In a separate terminal, curl the application with query `"pig"`.
 
 ```
 $ curl localhost:9000/search?q=pig
-["🐖","🐷","🐽"]
+["🐖","🐗","🐷","🐽"]
 ```
 
-Your application should return `["🐖","🐷","🐽"]` after a one second delay.
+Your application should return `["🐖","🐗","🐷","🐽"]` after a one second delay.
 Then, re-run the same curl command. This time, the request should return nearly
 instantly, as the results of query `"pig"` are now in the cache.
 

--- a/07/instructions_test.go
+++ b/07/instructions_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	// Start the single process server.
+	if err := exec.Command("weaver", "generate", ".").Run(); err != nil {
+		t.Fatalf("weaver generate .: %v", err)
+	}
+	single := exec.Command("go", "run", ".")
+	single.Env = append(single.Environ(), "SERVICEWEAVER_CONFIG=config.toml")
+	if err := single.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer single.Process.Kill()
+
+	// Give the single process server time to start.
+	time.Sleep(time.Second)
+
+	// Curl the single process server.
+	const url = "localhost:9000/search?q=pig"
+	const want = `["🐖","🐗","🐷","🐽"]` + "\n"
+	out, err := exec.Command("curl", url).Output()
+	if err != nil {
+		t.Fatalf("curl %s: %v", url, err)
+	}
+	if string(out) != want {
+		t.Fatalf("curl %s: got %q, want %q", url, string(out), want)
+	}
+
+	// Kill the single process server.
+	if err := single.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the multiprocess server.
+	if err := exec.Command("go", "build", ".").Run(); err != nil {
+		t.Fatalf("go build .: %v", err)
+	}
+	multi := exec.Command("weaver", "multi", "deploy", "config.toml")
+	if err := multi.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := multi.Process.Kill(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give the multiprocess server time to start.
+	time.Sleep(time.Second)
+
+	// Curl the multiprocess server.
+	for i := 0; i < 4; i++ {
+		out, err := exec.Command("curl", url).Output()
+		if err != nil {
+			t.Fatalf("curl %s: %v", url, err)
+		}
+		if string(out) != want {
+			t.Fatalf("curl %s: got %q, want %q", url, string(out), want)
+		}
+	}
+}

--- a/08/instructions_test.go
+++ b/08/instructions_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	if err := exec.Command("weaver", "generate", ".").Run(); err != nil {
+		t.Fatalf("weaver generate .: %v", err)
+	}
+
+	if err := exec.Command("go", "build", ".").Run(); err != nil {
+		t.Fatalf("go build .: %v", err)
+	}
+
+	// Start the server.
+	server := exec.Command("weaver", "multi", "deploy", "config.toml")
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := server.Process.Kill(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give the server time to start.
+	time.Sleep(time.Second)
+
+	// Curl the server.
+	const url = "localhost:9000/search?q=pig"
+	const want = `["🐖","🐗","🐷","🐽"]` + "\n"
+	for i := 0; i < 4; i++ {
+		out, err := exec.Command("curl", url).Output()
+		if err != nil {
+			t.Fatalf("curl %s: %v", url, err)
+		}
+		if string(out) != want {
+			t.Fatalf("curl %s: got %q, want %q", url, string(out), want)
+		}
+	}
+}

--- a/09/instructions_test.go
+++ b/09/instructions_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestInstructions tests that the instructions in README.md work as expected.
+// Workshop participants can ignore this file.
+func TestInstructions(t *testing.T) {
+	if err := exec.Command("go", "build", ".").Run(); err != nil {
+		t.Fatalf("go build .: %v", err)
+	}
+
+	// Start the server.
+	server := exec.Command("weaver", "multi", "deploy", "config.toml")
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := server.Process.Kill(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Give the server time to start.
+	time.Sleep(time.Second)
+
+	// Curl the server.
+	for _, url := range []string{
+		"localhost:9000/search?q=two",
+		"localhost:9000/search?q=two",
+		"localhost:9000/search?q=three",
+		"localhost:9000/search?q=three",
+		"localhost:9000/search?q=three",
+		"localhost:9000/search?q=four",
+		"localhost:9000/search?q=four",
+		"localhost:9000/search?q=four",
+		"localhost:9000/search?q=four",
+	} {
+		if err := exec.Command("curl", url).Run(); err != nil {
+			t.Fatalf("curl %s: %v", url, err)
+		}
+	}
+
+	// Fetch metrics.
+	if err := exec.Command("weaver", "multi", "metrics", "cache").Run(); err != nil {
+		t.Fatalf("weaver multi metrics cache: %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds a set of unit tests that run the commands listed in the workshop's instructions. Note that the unit tests literally run the commands, rather than doing something more direct, like the tests in searcher_test.go. This is intentional and aims to catch any small errors in the instructions we give participants.