### PR TITLE
Fixed unkilled process bug in instructions tests.

### DIFF
--- a/01/go.mod
+++ b/01/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.1
+	github.com/ServiceWeaver/weaver v0.19.0
 	go.opentelemetry.io/otel/trace v1.16.0
 )
 

--- a/01/go.sum
+++ b/01/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/01/weaver_gen.go
+++ b/01/weaver_gen.go
@@ -13,7 +13,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/02/go.mod
+++ b/02/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090

--- a/02/go.sum
+++ b/02/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/02/weaver_gen.go
+++ b/02/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/03/go.mod
+++ b/03/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/03/go.sum
+++ b/03/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/03/weaver_gen.go
+++ b/03/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/04/go.mod
+++ b/04/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/04/go.sum
+++ b/04/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/04/instructions_test.go
+++ b/04/instructions_test.go
@@ -23,8 +23,13 @@ import (
 // TestInstructions tests that the instructions in README.md work as expected.
 // Workshop participants can ignore this file.
 func TestInstructions(t *testing.T) {
+	// Build the server.
+	if err := exec.Command("go", "build", ".").Run(); err != nil {
+		t.Fatal(err)
+	}
+
 	// Start the server.
-	server := exec.Command("go", "run", ".")
+	server := exec.Command("./emojis")
 	server.Env = append(server.Environ(), "SERVICEWEAVER_CONFIG=config.toml")
 	if err := server.Start(); err != nil {
 		t.Fatal(err)

--- a/04/main.go
+++ b/04/main.go
@@ -42,7 +42,7 @@ type app struct {
 
 // run implements the application main.
 func run(ctx context.Context, a *app) error {
-	a.Logger().Info("emojis listener available.", "addr", a.lis)
+	a.Logger(ctx).Info("emojis listener available.", "addr", a.lis)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/04/weaver_gen.go
+++ b/04/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/05/go.mod
+++ b/05/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/05/go.sum
+++ b/05/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/05/instructions_test.go
+++ b/05/instructions_test.go
@@ -23,8 +23,13 @@ import (
 // TestInstructions tests that the instructions in README.md work as expected.
 // Workshop participants can ignore this file.
 func TestInstructions(t *testing.T) {
+	// Build the server.
+	if err := exec.Command("go", "build", ".").Run(); err != nil {
+		t.Fatal(err)
+	}
+
 	// Start the server.
-	server := exec.Command("go", "run", ".")
+	server := exec.Command("./emojis")
 	server.Env = append(server.Environ(), "SERVICEWEAVER_CONFIG=config.toml")
 	if err := server.Start(); err != nil {
 		t.Fatal(err)

--- a/05/main.go
+++ b/05/main.go
@@ -42,7 +42,7 @@ type app struct {
 
 // run implements the application main.
 func run(ctx context.Context, a *app) error {
-	a.Logger().Info("emojis listener available.", "addr", a.lis)
+	a.Logger(ctx).Info("emojis listener available.", "addr", a.lis)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/05/searcher.go
+++ b/05/searcher.go
@@ -35,7 +35,7 @@ type searcher struct {
 }
 
 func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
-	s.Logger().Debug("Search", "query", query)
+	s.Logger(ctx).Debug("Search", "query", query)
 
 	// Perform the search. First, we lowercase the query and split it into
 	// words. For example, the query "Black cat" is tokenized to the words

--- a/05/weaver_gen.go
+++ b/05/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/06/go.mod
+++ b/06/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/06/go.sum
+++ b/06/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/06/main.go
+++ b/06/main.go
@@ -42,7 +42,7 @@ type app struct {
 
 // run implements the application main.
 func run(ctx context.Context, a *app) error {
-	a.Logger().Info("emojis listener available.", "addr", a.lis)
+	a.Logger(ctx).Info("emojis listener available.", "addr", a.lis)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/06/searcher.go
+++ b/06/searcher.go
@@ -35,7 +35,7 @@ type searcher struct {
 }
 
 func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
-	s.Logger().Debug("Search", "query", query)
+	s.Logger(ctx).Debug("Search", "query", query)
 
 	// Perform the search. First, we lowercase the query and split it into
 	// words. For example, the query "Black cat" is tokenized to the words

--- a/06/weaver_gen.go
+++ b/06/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/07/cache.go
+++ b/07/cache.go
@@ -44,17 +44,17 @@ func (c *cache) Init(context.Context) error {
 	return nil
 }
 
-func (c *cache) Get(_ context.Context, query string) ([]string, error) {
+func (c *cache) Get(ctx context.Context, query string) ([]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Get", "query", query)
+	c.Logger(ctx).Debug("Get", "query", query)
 	return c.emojis[query], nil
 }
 
-func (c *cache) Put(_ context.Context, query string, emojis []string) error {
+func (c *cache) Put(ctx context.Context, query string, emojis []string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Put", "query", query)
+	c.Logger(ctx).Debug("Put", "query", query)
 	c.emojis[query] = emojis
 	return nil
 }

--- a/07/go.mod
+++ b/07/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/07/go.sum
+++ b/07/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/07/instructions_test.go
+++ b/07/instructions_test.go
@@ -27,12 +27,19 @@ func TestInstructions(t *testing.T) {
 	if err := exec.Command("weaver", "generate", ".").Run(); err != nil {
 		t.Fatalf("weaver generate .: %v", err)
 	}
-	single := exec.Command("go", "run", ".")
+	if err := exec.Command("go", "build", ".").Run(); err != nil {
+		t.Fatalf("go build .: %v", err)
+	}
+	single := exec.Command("./emojis")
 	single.Env = append(single.Environ(), "SERVICEWEAVER_CONFIG=config.toml")
 	if err := single.Start(); err != nil {
 		t.Fatal(err)
 	}
-	defer single.Process.Kill()
+	defer func() {
+		if err := single.Process.Kill(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	// Give the single process server time to start.
 	time.Sleep(time.Second)

--- a/07/main.go
+++ b/07/main.go
@@ -42,7 +42,7 @@ type app struct {
 
 // run implements the application main.
 func run(ctx context.Context, a *app) error {
-	a.Logger().Info("emojis listener available.", "addr", a.lis)
+	a.Logger(ctx).Info("emojis listener available.", "addr", a.lis)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/07/searcher.go
+++ b/07/searcher.go
@@ -36,12 +36,12 @@ type searcher struct {
 }
 
 func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
-	s.Logger().Debug("Search", "query", query)
+	s.Logger(ctx).Debug("Search", "query", query)
 
 	// Try to get the emojis from the cache, but continue if it's not found or
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
-		s.Logger().Error("cache.Get", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
 	} else if len(emojis) > 0 {
 		return emojis, nil
 	}
@@ -68,7 +68,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 
 	// Try to cache the results, but continue if there is an error.
 	if err := s.cache.Get().Put(ctx, query, results); err != nil {
-		s.Logger().Error("cache.Put", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Put", "query", query, "err", err)
 	}
 
 	return results, nil

--- a/07/weaver_gen.go
+++ b/07/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/08/cache.go
+++ b/08/cache.go
@@ -45,17 +45,17 @@ func (c *cache) Init(context.Context) error {
 	return nil
 }
 
-func (c *cache) Get(_ context.Context, query string) ([]string, error) {
+func (c *cache) Get(ctx context.Context, query string) ([]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Get", "query", query)
+	c.Logger(ctx).Debug("Get", "query", query)
 	return c.emojis[query], nil
 }
 
-func (c *cache) Put(_ context.Context, query string, emojis []string) error {
+func (c *cache) Put(ctx context.Context, query string, emojis []string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Put", "query", query)
+	c.Logger(ctx).Debug("Put", "query", query)
 	c.emojis[query] = emojis
 	return nil
 }

--- a/08/go.mod
+++ b/08/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/08/go.sum
+++ b/08/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/08/main.go
+++ b/08/main.go
@@ -42,7 +42,7 @@ type app struct {
 
 // run implements the application main.
 func run(ctx context.Context, a *app) error {
-	a.Logger().Info("emojis listener available.", "addr", a.lis)
+	a.Logger(ctx).Info("emojis listener available.", "addr", a.lis)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/08/searcher.go
+++ b/08/searcher.go
@@ -36,12 +36,12 @@ type searcher struct {
 }
 
 func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
-	s.Logger().Debug("Search", "query", query)
+	s.Logger(ctx).Debug("Search", "query", query)
 
 	// Try to get the emojis from the cache, but continue if it's not found or
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
-		s.Logger().Error("cache.Get", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
 	} else if len(emojis) > 0 {
 		return emojis, nil
 	}
@@ -68,7 +68,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 
 	// Try to cache the results, but continue if there is an error.
 	if err := s.cache.Get().Put(ctx, query, results); err != nil {
-		s.Logger().Error("cache.Put", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Put", "query", query, "err", err)
 	}
 
 	return results, nil

--- a/08/weaver_gen.go
+++ b/08/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/09/cache.go
+++ b/09/cache.go
@@ -45,17 +45,17 @@ func (c *cache) Init(context.Context) error {
 	return nil
 }
 
-func (c *cache) Get(_ context.Context, query string) ([]string, error) {
+func (c *cache) Get(ctx context.Context, query string) ([]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Get", "query", query)
+	c.Logger(ctx).Debug("Get", "query", query)
 	return c.emojis[query], nil
 }
 
-func (c *cache) Put(_ context.Context, query string, emojis []string) error {
+func (c *cache) Put(ctx context.Context, query string, emojis []string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Put", "query", query)
+	c.Logger(ctx).Debug("Put", "query", query)
 	c.emojis[query] = emojis
 	return nil
 }

--- a/09/go.mod
+++ b/09/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/09/go.sum
+++ b/09/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/09/main.go
+++ b/09/main.go
@@ -42,7 +42,7 @@ type app struct {
 
 // run implements the application main.
 func run(ctx context.Context, a *app) error {
-	a.Logger().Info("emojis listener available.", "addr", a.lis)
+	a.Logger(ctx).Info("emojis listener available.", "addr", a.lis)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/09/searcher.go
+++ b/09/searcher.go
@@ -49,12 +49,12 @@ type searcher struct {
 }
 
 func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
-	s.Logger().Debug("Search", "query", query)
+	s.Logger(ctx).Debug("Search", "query", query)
 
 	// Try to get the emojis from the cache, but continue if it's not found or
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
-		s.Logger().Error("cache.Get", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
 	} else if len(emojis) > 0 {
 		cacheHits.Add(1)
 		return emojis, nil
@@ -84,7 +84,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 
 	// Try to cache the results, but continue if there is an error.
 	if err := s.cache.Get().Put(ctx, query, results); err != nil {
-		s.Logger().Error("cache.Put", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Put", "query", query, "err", err)
 	}
 
 	return results, nil

--- a/09/weaver_gen.go
+++ b/09/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.

--- a/10/cache.go
+++ b/10/cache.go
@@ -45,17 +45,17 @@ func (c *cache) Init(context.Context) error {
 	return nil
 }
 
-func (c *cache) Get(_ context.Context, query string) ([]string, error) {
+func (c *cache) Get(ctx context.Context, query string) ([]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Get", "query", query)
+	c.Logger(ctx).Debug("Get", "query", query)
 	return c.emojis[query], nil
 }
 
-func (c *cache) Put(_ context.Context, query string, emojis []string) error {
+func (c *cache) Put(ctx context.Context, query string, emojis []string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Logger().Debug("Put", "query", query)
+	c.Logger(ctx).Debug("Put", "query", query)
 	c.emojis[query] = emojis
 	return nil
 }

--- a/10/go.mod
+++ b/10/go.mod
@@ -3,7 +3,7 @@ module emojis
 go 1.20
 
 require (
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.19.0
 	github.com/google/go-cmp v0.5.9
 	github.com/rivo/uniseg v0.4.4
 	github.com/sashabaranov/go-openai v1.14.1

--- a/10/go.sum
+++ b/10/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146 h1:S5WsRc58vIeuhvbz0V0FKs19nTbh5z23DCutLIXJkFA=
 github.com/DataDog/hyperloglog v0.0.0-20220804205443-1806d9b66146/go.mod h1:hFPkswc42pKhRbeKDKXy05mRi7J1kJ2vMNbvd9erH0M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
-github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
-github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.19.0 h1:iGf4XkmohY8pTaQJv59N+YIoI+CSTnAWxls5gFwfiVQ=
+github.com/ServiceWeaver/weaver v0.19.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/10/main.go
+++ b/10/main.go
@@ -42,7 +42,7 @@ type app struct {
 
 // run implements the application main.
 func run(ctx context.Context, a *app) error {
-	a.Logger().Info("emojis listener available.", "addr", a.lis)
+	a.Logger(ctx).Info("emojis listener available.", "addr", a.lis)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/10/searcher.go
+++ b/10/searcher.go
@@ -56,12 +56,12 @@ type searcher struct {
 }
 
 func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
-	s.Logger().Debug("Search", "query", query)
+	s.Logger(ctx).Debug("Search", "query", query)
 
 	// Try to get the emojis from the cache, but continue if it's not found or
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
-		s.Logger().Error("cache.Get", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
 	} else if len(emojis) > 0 {
 		cacheHits.Add(1)
 		return emojis, nil
@@ -91,7 +91,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 
 	// Try to cache the results, but continue if there is an error.
 	if err := s.cache.Get().Put(ctx, query, results); err != nil {
-		s.Logger().Error("cache.Put", "query", query, "err", err)
+		s.Logger(ctx).Error("cache.Put", "query", query, "err", err)
 	}
 
 	return results, nil
@@ -114,7 +114,7 @@ func (s *searcher) SearchChatGPT(ctx context.Context, query string) ([]string, e
 	if err != nil {
 		return nil, fmt.Errorf("chatgpt: %w", err)
 	}
-	s.Logger().Debug("ChatGPT completion", "query", query, "completion", completion)
+	s.Logger(ctx).Debug("ChatGPT completion", "query", query, "completion", completion)
 
 	// Parse the emojis from ChatGPT's response. This is surprisingly tricky
 	// since some emoji sequences contain many codepoints, and not every

--- a/10/weaver_gen.go
+++ b/10/weaver_gen.go
@@ -15,7 +15,7 @@ import (
 
 var _ codegen.LatestVersion = codegen.Version[[0][17]struct{}](`
 
-ERROR: You generated this file with 'weaver generate' v0.18.0 (codegen
+ERROR: You generated this file with 'weaver generate' v0.19.0 (codegen
 version v0.17.0). The generated code is incompatible with the version of the
 github.com/ServiceWeaver/weaver module that you're using. The weaver module
 version can be found in your go.mod file or by running the following command.


### PR DESCRIPTION
Some of the instructions tests run "go run ." in a subprocess and kill the subprocess at the end of the test. However, "go run ." internally builds a binary and runs it as a subprocess. Killing "go run ." was killing "go run ." (duh), but it wasn't killing the underlying binary. This PR fixes that by building and running the binary directly, rather than using "go run .".