### PR TITLE
Fixed zsh question mark (?) escaping bug.

### DIFF
--- a/04/README.md
+++ b/04/README.md
@@ -16,7 +16,7 @@ Next, inside of the function you pass to `weaver.Run`, implement an HTTP handler
 for the `/search` endpoint. The endpoint receives GET requests of the form
 `/search?q=<query>` and returns the JSON serialized list of emojis that match
 the query ([`json.Marshal`](https://pkg.go.dev/encoding/json#Marshal)). For
-example, `curl localhost:9000/search?q=pig` should return
+example, `curl "localhost:9000/search?q=pig"` should return
 `["🐖","🐗","🐷","🐽"]`. At the end of the function, call
 [`http.Serve`][http.Serve] to serve HTTP traffic using the handler you just
 implemented.
@@ -47,11 +47,11 @@ $ SERVICEWEAVER_CONFIG=config.toml go run .
 In a separate terminal, curl the `/search` endpoint:
 
 ```
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
-$ curl localhost:9000/search?q=cow
+$ curl "localhost:9000/search?q=cow"
 ["🐄","🐮"]
-$ curl localhost:9000/search?q=baby%20bird
+$ curl "localhost:9000/search?q=baby%20bird"
 ["🐣","🐤","🐥"]
 ```
 

--- a/05/README.md
+++ b/05/README.md
@@ -19,13 +19,13 @@ $ SERVICEWEAVER_CONFIG=config.toml go run .
 In a separate terminal, curl the application a couple of times:
 
 ```
-$ curl localhost:9000/search?q=sushi
+$ curl "localhost:9000/search?q=sushi"
 ["🍣"]
-$ curl localhost:9000/search?q=curry
+$ curl "localhost:9000/search?q=curry"
 ["🍛"]
-$ curl localhost:9000/search?q=shrimp
+$ curl "localhost:9000/search?q=shrimp"
 ["🍤","🦐"]
-$ curl localhost:9000/search?q=lobster
+$ curl "localhost:9000/search?q=lobster"
 ["🦞"]
 ```
 

--- a/06/README.md
+++ b/06/README.md
@@ -63,13 +63,13 @@ process ids are distinct.
 Curl your application couple of times:
 
 ```
-$ curl localhost:9000/search?q=sushi
+$ curl "localhost:9000/search?q=sushi"
 ["🍣"]
-$ curl localhost:9000/search?q=curry
+$ curl "localhost:9000/search?q=curry"
 ["🍛"]
-$ curl localhost:9000/search?q=shrimp
+$ curl "localhost:9000/search?q=shrimp"
 ["🍤", "🦐"]
-$ curl localhost:9000/search?q=lobster
+$ curl "localhost:9000/search?q=lobster"
 ["🦞"]
 ```
 

--- a/07/README.md
+++ b/07/README.md
@@ -53,7 +53,7 @@ $ SERVICEWEAVER_CONFIG=config.toml go run .
 In a separate terminal, curl the application with query `"pig"`.
 
 ```
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
 ```
 
@@ -62,7 +62,7 @@ Then, re-run the same curl command. This time, the request should return nearly
 instantly, as the results of query `"pig"` are now in the cache.
 
 ```
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
 ```
 
@@ -77,13 +77,13 @@ And again in a separate terminal, repeatedly curl the application with query
 `"pig"`:
 
 ```
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
 ```
 

--- a/08/README.md
+++ b/08/README.md
@@ -32,13 +32,13 @@ $ weaver multi deploy config.toml
 And again in a separate terminal, repeatedly curl the application.
 
 ```
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
-$ curl localhost:9000/search?q=pig
+$ curl "localhost:9000/search?q=pig"
 ["🐖","🐗","🐷","🐽"]
 ```
 

--- a/09/README.md
+++ b/09/README.md
@@ -32,15 +32,15 @@ In a separate terminal, curl your application with various queries, making sure
 to repeat some requests.
 
 ```
-$ curl localhost:9000/search?q=two    # MISS 1
-$ curl localhost:9000/search?q=two    # HIT  1
-$ curl localhost:9000/search?q=three  # MISS 2
-$ curl localhost:9000/search?q=three  # HIT  2
-$ curl localhost:9000/search?q=three  # HIT  3
-$ curl localhost:9000/search?q=four   # MISS 3
-$ curl localhost:9000/search?q=four   # HIT  4
-$ curl localhost:9000/search?q=four   # HIT  5
-$ curl localhost:9000/search?q=four   # HIT  6
+$ curl "localhost:9000/search?q=two"    # MISS 1
+$ curl "localhost:9000/search?q=two"    # HIT  1
+$ curl "localhost:9000/search?q=three"  # MISS 2
+$ curl "localhost:9000/search?q=three"  # HIT  2
+$ curl "localhost:9000/search?q=three"  # HIT  3
+$ curl "localhost:9000/search?q=four"   # MISS 3
+$ curl "localhost:9000/search?q=four"   # HIT  4
+$ curl "localhost:9000/search?q=four"   # HIT  5
+$ curl "localhost:9000/search?q=four"   # HIT  6
 ```
 
 Run `weaver multi metrics` to see a snapshot of the metric values.

--- a/10/README.md
+++ b/10/README.md
@@ -167,7 +167,7 @@ $ weaver multi deploy config.toml
 You can curl the `/search_chatgpt` endpoint directly:
 
 ```console
-$ curl localhost:9000/search_chatgpt?q=happy
+$ curl "localhost:9000/search_chatgpt?q=happy"
 ["😀","😁","😃","😄","😊","😍","😎","🤗","😻","🌞","🎉","🎊","🎁","🎈","💐","👍","✨","🌟","💫","🌈"]
 ```
 


### PR DESCRIPTION
On zsh, the question mark (?) is used in [globbing][glob] to match any single character, like a `.` in regular expressions. Our instructions had curl commands like `curl localhost:9000/search?q=pig` that contained question marks. When workshop participants copy and pasted these commands into zsh, they did not work because zsh tried to glob the question mark. This PR double quotes the addresses to disable globbing and make the commands work on zsh.

[glob]: https://en.wikipedia.org/wiki/Glob_(programming)