### PR TITLE
Fixed caching of queries with no matching emojis.

### DIFF
--- a/02/searcher.go
+++ b/02/searcher.go
@@ -47,7 +47,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/03/searcher.go
+++ b/03/searcher.go
@@ -47,7 +47,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/03/searcher_test.go
+++ b/03/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)

--- a/04/searcher.go
+++ b/04/searcher.go
@@ -47,7 +47,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/04/searcher_test.go
+++ b/04/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)

--- a/05/searcher.go
+++ b/05/searcher.go
@@ -49,7 +49,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/05/searcher_test.go
+++ b/05/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)

--- a/06/searcher.go
+++ b/06/searcher.go
@@ -49,7 +49,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/06/searcher_test.go
+++ b/06/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)

--- a/07/searcher.go
+++ b/07/searcher.go
@@ -42,7 +42,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
 		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
-	} else if len(emojis) > 0 {
+	} else if emojis != nil {
 		return emojis, nil
 	}
 
@@ -58,7 +58,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/07/searcher_test.go
+++ b/07/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)

--- a/08/searcher.go
+++ b/08/searcher.go
@@ -42,7 +42,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
 		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
-	} else if len(emojis) > 0 {
+	} else if emojis != nil {
 		return emojis, nil
 	}
 
@@ -58,7 +58,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/08/searcher_test.go
+++ b/08/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)

--- a/09/searcher.go
+++ b/09/searcher.go
@@ -55,7 +55,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
 		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
-	} else if len(emojis) > 0 {
+	} else if emojis != nil {
 		cacheHits.Inc()
 		return emojis, nil
 	} else {
@@ -74,7 +74,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/09/searcher_test.go
+++ b/09/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)

--- a/10/searcher.go
+++ b/10/searcher.go
@@ -62,7 +62,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	// there is an error.
 	if emojis, err := s.cache.Get().Get(ctx, query); err != nil {
 		s.Logger(ctx).Error("cache.Get", "query", query, "err", err)
-	} else if len(emojis) > 0 {
+	} else if emojis != nil {
 		cacheHits.Inc()
 		return emojis, nil
 	} else {
@@ -81,7 +81,7 @@ func (s *searcher) Search(ctx context.Context, query string) ([]string, error) {
 	//
 	// We iterate over all emojis and return the ones that match the query.
 	words := strings.Fields(strings.ToLower(query))
-	var results []string
+	results := []string{}
 	for emoji, labels := range emojis {
 		if matches(labels, words) {
 			results = append(results, emoji)

--- a/10/searcher_test.go
+++ b/10/searcher_test.go
@@ -33,7 +33,7 @@ func TestSearch(t *testing.T) {
 		{"pig", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"PiG", []string{"🐖", "🐗", "🐷", "🐽"}},
 		{"black cat", []string{"🐈\u200d⬛"}},
-		{"foo bar baz", nil},
+		{"foo bar baz", []string{}},
 	} {
 		for _, runner := range weavertest.AllRunners() {
 			runner.Name = fmt.Sprintf("%s/%q", runner.Name, test.query)


### PR DESCRIPTION
Recall that the `Searcher` component has a `Search` method that returns the set of emojis that match a provided query. In part 7 of the workshop, we add a `Cache` component and update the `Searcher` component to cache query results.

@spetrovic77 pointed out that our caching is buggy. Specifically, we do not cache queries that don't have any matching emojis. This PR fixes the bug, being careful to distinguish between when the `Cache` returns `nil` (meaning there is nothing cached) and when it returns `[]string{}` (meaning it has cached the fact that there are no matching emojis).

A better solution would be to introduce a custom error value that is returned when there is a cache miss, but that would require explaining `AutoMarshal` and error serialization, which I think would be too complicated for the workshop. Instead, we do a slightly jankier but simpler fix.