### PR TITLE
Bumped Go version in deploy script to 1.21.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Retrieve weaver version
       run: |


### PR DESCRIPTION
The [deploy script was failing][1] with the following error:

```
../../../go/pkg/mod/github.com/!service!weaver/weaver@v0.21.2/runtime/protomsg/handler.go:22:2: package log/slog is not in GOROOT
(/opt/hostedtoolcache/go/1.20.7/x64/src/log/slog)
```

I noticed that the deploy script was using go 1.20, but slog was released in go 1.21.

[1]: https://github.com/ServiceWeaver/workshops/actions/runs/6174995348/job/16760876660