### PR TITLE
[fix][README] render ⚫ emoji correctly by adding a space

### DIFF
--- a/02/README.md
+++ b/02/README.md
@@ -56,7 +56,7 @@ ever fails to build with an error coming from a `weaver_gen.go` file, try
 re-running `weaver generate`.
 
 [**:arrow_left: Previous Part**](../01)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../03)
 
 [fundamental_theorem]: https://en.wikipedia.org/wiki/Fundamental_theorem_of_arithmetic

--- a/03/README.md
+++ b/03/README.md
@@ -27,7 +27,7 @@ ok	emojis	0.491s
 ```
 
 [**:arrow_left: Previous Part**](../02)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../04)
 
 [testing]: https://serviceweaver.dev/docs.html#testing

--- a/04/README.md
+++ b/04/README.md
@@ -131,7 +131,7 @@ the following web UI.
 [emoji_search_demo.webm](https://github.com/ServiceWeaver/workshops/assets/3654277/8ced2cb0-18c2-41fc-b14f-cc4f602deb38)
 
 [**:arrow_left: Previous Part**](../03)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../05)
 
 [listeners]: https://serviceweaver.dev/docs.html#step-by-step-tutorial-listeners

--- a/05/README.md
+++ b/05/README.md
@@ -46,7 +46,7 @@ id. Then comes the file and line where the log was produced, followed finally by
 the contents of the log.
 
 [**:arrow_left: Previous Part**](../04)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../06)
 
 [logging]: https://serviceweaver.dev/docs.html#logging

--- a/06/README.md
+++ b/06/README.md
@@ -85,7 +85,7 @@ D0525 09:40:36.534745 emojis.Searcher d29c6296 searcher.go:53] Search query="lob
 ```
 
 [**:arrow_left: Previous Part**](../05)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../07)
 
 [multiprocess]: https://serviceweaver.dev/docs.html#step-by-step-tutorial-multiprocess-execution

--- a/07/README.md
+++ b/07/README.md
@@ -133,7 +133,7 @@ In the next part, we'll see how to prevent this surprising behavior from
 happening.
 
 [**:arrow_left: Previous Part**](../06)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../08)
 
 [component_semantics]: https://serviceweaver.dev/docs.html#components-semantics

--- a/08/README.md
+++ b/08/README.md
@@ -63,7 +63,7 @@ Notice that every `Get` and `Put` is routed to replica `e1ef982f`. At this
 point, feel free to remove the `time.Sleep(time.Second)` call from your code.
 
 [**:arrow_left: Previous Part**](../07)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../09)
 
 [routing]: https://serviceweaver.dev/docs.html#routing

--- a/09/README.md
+++ b/09/README.md
@@ -86,7 +86,7 @@ and [multiprocess metrics][multiprocess_metrics] for instructions on how to view
 metrics using Prometheus.
 
 [**:arrow_left: Previous Part**](../08)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Next Part :arrow_right:**](../10)
 
 [metrics]: https://serviceweaver.dev/docs.html#metrics

--- a/10/README.md
+++ b/10/README.md
@@ -178,7 +178,7 @@ parallel and merges the results together.
 [emoji_search_demo.webm](https://github.com/ServiceWeaver/workshops/assets/3654277/cde50b36-7808-4c26-983d-54a37532e69a)
 
 [**:arrow_left: Previous Part**](../09)
-&nbsp;&nbsp;&nbsp;:black_circle:&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp; :black_circle: &nbsp;&nbsp;&nbsp;
 [**Home :house:**](..)
 
 [ChatCompletionRequest]: https://pkg.go.dev/github.com/sashabaranov/go-openai#ChatCompletionRequest


### PR DESCRIPTION
There is an issue currently that fails ⚫  from rendering in the tutorial READMEs.
Adding a space on both sides fixes the issue.

<img width="484" alt="Screenshot 2024-04-23 at 11 11 25 AM" src="https://github.com/ServiceWeaver/workshops/assets/11318551/d1a37349-1bb6-4f29-885a-64236c652c13">
